### PR TITLE
Update name of GitHub card

### DIFF
--- a/docs/introduction.mdx
+++ b/docs/introduction.mdx
@@ -50,7 +50,7 @@ Learn how to set up Cloudanix for your cloud Platform by selecting one of the fo
 </Card>
 
 <Card
-  title="GCP"
+  title="GitHub"
   icon={brands("github")}
   color="#171515"
   href="/github/github-authentication"


### PR DESCRIPTION
# Summary

There was previously a typo on the last navigation card from introduction that made two `GCP`s when the second one should have been `GitHub`

<img width="732" alt="Screen Shot 2022-09-10 at 11 26 55 PM" src="https://user-images.githubusercontent.com/44352119/189515257-49aa1d6f-8ee8-48ba-ac27-facdcf826d6f.png">
