### PR TITLE
Object lock remediation changed

### DIFF
--- a/docs/aws/audit/s3publiccheck/rules/object_lock.mdx
+++ b/docs/aws/audit/s3publiccheck/rules/object_lock.mdx
@@ -24,87 +24,29 @@ HIPAA, SOC2
 
 #### Using Console
 
-Sure, here are the step-by-step instructions to remediate the S3 Buckets Should Have Object Lock Enabled misconfiguration in AWS using the AWS console:
+To remediate the issue of not being able to enable S3 Bucket Object Lock after bucket creation using AWS Customer Support, you can follow these steps:
 
-1. Login to AWS Management Console.
-2. Navigate to the S3 service.
-3. Select the bucket that needs to be remediated.
-4. Click on the "Properties" tab.
-5. Scroll down and click on the "Object lock" option.
-6. Click on the "Edit" button.
-7. Select "Enable object lock" and then click on the "Save changes" button.
+1. Open the AWS Support Center:
+   - Sign in to the AWS Management Console.
+   - Open the AWS Support Center at https://console.aws.amazon.com/support/.
 
-Once you have followed these steps, the Object Lock feature will be enabled for the selected S3 bucket. This will ensure that all objects stored in the bucket are protected from deletion or modification for the specified retention period.
+2. Create a new support case:
+   - Click on "Create case" to initiate a new support case.
+   - Select the appropriate support plan for your AWS account.
 
-#### Using CLI
+3. Provide necessary details:
+   - In the "Regarding" field, select "Amazon S3" as the service.
+   - Choose the appropriate category and severity for your case.
+   - Provide a clear and concise description of the issue, explaining that you need to enable Object Lock on an existing S3 bucket and it's currently not possible after bucket creation.
 
-To remediate the misconfiguration "S3 Buckets Should Have Object Lock Enabled" for AWS using AWS CLI, follow the steps below:
+4. Submit the support case:
+   - Review the details you have provided and make sure they are accurate.
+   - Click on "Submit" to create the support case.
 
-1. Open the AWS CLI on your local machine or EC2 instance.
-
-2. Run the following command to enable Object Lock on the S3 bucket:
-
-```
-aws s3api put-object-lock-configuration --bucket <bucket-name> --object-lock-configuration '{"ObjectLockEnabled":"Enabled"}'
-```
-
-Make sure to replace `<bucket-name>` with the name of your S3 bucket.
-
-3. Verify that Object Lock is enabled on the S3 bucket by running the following command:
-
-```
-aws s3api get-object-lock-configuration --bucket <bucket-name>
-```
-
-This command should return the Object Lock configuration for the S3 bucket, which should include `"ObjectLockEnabled": "Enabled"`.
-
-By following these steps, you can remediate the misconfiguration "S3 Buckets Should Have Object Lock Enabled" for AWS using AWS CLI.
-
-#### Using Python
-
-To remediate the misconfiguration of S3 Buckets not having Object Lock enabled in AWS using Python, follow these steps:
-
-1. Install `boto3` library for AWS SDK for Python using the following command:
-
-```python
-pip install boto3
-```
-
-2. Create an AWS S3 client using `boto3` and provide the AWS access key and secret key:
-
-```python
-import boto3
-
-s3 = boto3.client('s3', aws_access_key_id='YOUR_ACCESS_KEY',
-                  aws_secret_access_key='YOUR_SECRET_KEY')
-```
-
-3. Get the list of all S3 buckets in your AWS account using the following command:
-
-```python
-response = s3.list_buckets()
-buckets = [bucket['Name'] for bucket in response['Buckets']]
-```
-
-4. For each S3 bucket, check if Object Lock is enabled or not using the following code:
-
-```python
-for bucket in buckets:
-    response = s3.get_bucket_object_lock_configuration(Bucket=bucket)
-    if 'ObjectLockEnabled' not in response:
-        # Object Lock is not enabled for the bucket
-        # Enable Object Lock for the bucket
-        response = s3.put_bucket_object_lock_configuration(
-            Bucket=bucket,
-            ObjectLockConfiguration={
-                'ObjectLockEnabled': 'Enabled'
-            }
-        )
-```
-
-5. Save the Python script and run it to enable Object Lock for all S3 buckets in your AWS account.
-
-Note: Make sure to provide the correct AWS access key and secret key with the required permissions to access and modify S3 buckets.
+5. Engage with AWS Customer Support:
+   - An AWS Support representative will review your case and reach out to you for further clarification or information if needed.
+   - Work closely with the representative to explain your requirements and inquire about possible solutions or workarounds.
+   - AWS Customer Support will provide guidance and assistance to help resolve the issue, which may involve actions on their end or providing alternative options.
 
 ### Additional Reading:
 

--- a/docs/aws/audit/s3publiccheck/rules/object_lock_remediation.mdx
+++ b/docs/aws/audit/s3publiccheck/rules/object_lock_remediation.mdx
@@ -2,85 +2,26 @@
 
 #### Using Console
 
-Sure, here are the step-by-step instructions to remediate the S3 Buckets Should Have Object Lock Enabled misconfiguration in AWS using the AWS console:
+To remediate the issue of not being able to enable S3 Bucket Object Lock after bucket creation using AWS Customer Support, you can follow these steps:
 
-1. Login to AWS Management Console.
-2. Navigate to the S3 service.
-3. Select the bucket that needs to be remediated.
-4. Click on the "Properties" tab.
-5. Scroll down and click on the "Object lock" option.
-6. Click on the "Edit" button.
-7. Select "Enable object lock" and then click on the "Save changes" button.
+1. Open the AWS Support Center:
+   - Sign in to the AWS Management Console.
+   - Open the AWS Support Center at https://console.aws.amazon.com/support/.
 
-Once you have followed these steps, the Object Lock feature will be enabled for the selected S3 bucket. This will ensure that all objects stored in the bucket are protected from deletion or modification for the specified retention period.
+2. Create a new support case:
+   - Click on "Create case" to initiate a new support case.
+   - Select the appropriate support plan for your AWS account.
 
-#### Using CLI
+3. Provide necessary details:
+   - In the "Regarding" field, select "Amazon S3" as the service.
+   - Choose the appropriate category and severity for your case.
+   - Provide a clear and concise description of the issue, explaining that you need to enable Object Lock on an existing S3 bucket and it's currently not possible after bucket creation.
 
-To remediate the misconfiguration "S3 Buckets Should Have Object Lock Enabled" for AWS using AWS CLI, follow the steps below:
+4. Submit the support case:
+   - Review the details you have provided and make sure they are accurate.
+   - Click on "Submit" to create the support case.
 
-1. Open the AWS CLI on your local machine or EC2 instance.
-
-2. Run the following command to enable Object Lock on the S3 bucket:
-
-```
-aws s3api put-object-lock-configuration --bucket <bucket-name> --object-lock-configuration '{"ObjectLockEnabled":"Enabled"}'
-```
-
-Make sure to replace `<bucket-name>` with the name of your S3 bucket.
-
-3. Verify that Object Lock is enabled on the S3 bucket by running the following command:
-
-```
-aws s3api get-object-lock-configuration --bucket <bucket-name>
-```
-
-This command should return the Object Lock configuration for the S3 bucket, which should include `"ObjectLockEnabled": "Enabled"`.
-
-By following these steps, you can remediate the misconfiguration "S3 Buckets Should Have Object Lock Enabled" for AWS using AWS CLI.
-
-#### Using Python
-
-To remediate the misconfiguration of S3 Buckets not having Object Lock enabled in AWS using Python, follow these steps:
-
-1. Install `boto3` library for AWS SDK for Python using the following command:
-
-```python
-pip install boto3
-```
-
-2. Create an AWS S3 client using `boto3` and provide the AWS access key and secret key:
-
-```python
-import boto3
-
-s3 = boto3.client('s3', aws_access_key_id='YOUR_ACCESS_KEY',
-                  aws_secret_access_key='YOUR_SECRET_KEY')
-```
-
-3. Get the list of all S3 buckets in your AWS account using the following command:
-
-```python
-response = s3.list_buckets()
-buckets = [bucket['Name'] for bucket in response['Buckets']]
-```
-
-4. For each S3 bucket, check if Object Lock is enabled or not using the following code:
-
-```python
-for bucket in buckets:
-    response = s3.get_bucket_object_lock_configuration(Bucket=bucket)
-    if 'ObjectLockEnabled' not in response:
-        # Object Lock is not enabled for the bucket
-        # Enable Object Lock for the bucket
-        response = s3.put_bucket_object_lock_configuration(
-            Bucket=bucket,
-            ObjectLockConfiguration={
-                'ObjectLockEnabled': 'Enabled'
-            }
-        )
-```
-
-5. Save the Python script and run it to enable Object Lock for all S3 buckets in your AWS account.
-
-Note: Make sure to provide the correct AWS access key and secret key with the required permissions to access and modify S3 buckets.
-
+5. Engage with AWS Customer Support:
+   - An AWS Support representative will review your case and reach out to you for further clarification or information if needed.
+   - Work closely with the representative to explain your requirements and inquire about possible solutions or workarounds.
+   - AWS Customer Support will provide guidance and assistance to help resolve the issue, which may involve actions on their end or providing alternative options.


### PR DESCRIPTION
Object lock remediation changed.
Currently cannot enable object lock after bucket creation, so added remediation of contacting AWS support team.